### PR TITLE
check cacheMarquees="false"

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -784,7 +784,9 @@ void Cache::assembleReport(const Settings &config, const QString filter)
       resTypeList.append("cover");
       resTypeList.append("screenshot");
       resTypeList.append("wheel");
-      resTypeList.append("marquee");
+      if(config.cacheMarquees){
+        resTypeList.append("marquee");
+      }
       resTypeList.append("texture");
       resTypeList.append("video");
     } else if(missingOption == "textual") {
@@ -802,13 +804,17 @@ void Cache::assembleReport(const Settings &config, const QString filter)
       resTypeList.append("cover");
       resTypeList.append("screenshot");
       resTypeList.append("wheel");
-      resTypeList.append("marquee");
+      if(config.cacheMarquees){
+        resTypeList.append("marquee");
+      }
       resTypeList.append("texture");
     } else if(missingOption == "media") {
       resTypeList.append("cover");
       resTypeList.append("screenshot");
       resTypeList.append("wheel");
-      resTypeList.append("marquee");
+      if(config.cacheMarquees){
+        resTypeList.append("marquee");
+      }
       resTypeList.append("texture");
       resTypeList.append("video");
     } else {


### PR DESCRIPTION
If **cacheMarquee="false"** then don't generate cache report for Marquee.
I verified marquee report is not generated with cache report for all, media and artwork. Example:
`Skyscraper -p ps2 --cache report:missing=all`
`Skyscraper -p ps2 --cache report:missing=media`
`Skyscraper -p ps2 --cache report:missing=artwork`

You can still manually report on marquee individually. Example:
`Skyscraper -p ps2 --cache report:missing=marquee`