### PR TITLE
Pegasus frontend: Handle 'extra' based on command/launch lines

### DIFF
--- a/src/pegasus.h
+++ b/src/pegasus.h
@@ -52,6 +52,7 @@ public:
 private:
   QString makeAbsolute(const QString &filePath, const QString &inputFolder);
   QString fromPreservedHeader(const QString &key, const QString &suggested);
+  bool hasPreservedHeader(const QString &key);
   void removePreservedHeader(const QString &key);
   QString toPegasusFormat(const QString &key, const QString &value);
   QList<QPair<QString, QString> > headerPairs;


### PR DESCRIPTION
This changes Pegasus output to handle the `-e <STRING>` argument and `command:`/`launch:` differently:

* If `-e` was not provided (or was provided empty), utilize the existing `command:` OR `launch:` tag (which are aliases of each other, and the later is what the [Metadata Generator](https://pegasus-frontend.org/tools/metagen-android/) writes)
    * Otherwise, there was no way to tell skyscraper to just use the existing pre-fab'd metadata from e.g. the [Metadata Generator](https://pegasus-frontend.org/tools/metagen-android/)
* If `-e` was provided, always use that
* Always write `command` (or `launch`) last, since that is generally a multi-line command