### PR TITLE
Added Miyoo frontend support

### DIFF
--- a/docs/FRONTENDS.md
+++ b/docs/FRONTENDS.md
@@ -20,7 +20,17 @@ Skyscraper will preserve the following metadata when re-generating a game list f
 * Default game list location: `/home/pi/USER/RetroPie/roms/PLATFORM`
 * Default game list filename: `gamelist.xml`
 
-This is modeled after EmualtionStation as it uses it with slight differences.
+This is modeled after EmulationStation as it uses it with slight differences.
+
+#### Miyoo
+* Default game list location: (should be specified to the Miyoo SD card)
+* Default game list filename: `miyoogamelist.xml`
+
+Outputs a [miyoogamelist.xml](https://github.com/OnionUI/Onion/wiki/Frequently-Asked-Questions-%28FAQ%29#how-can-i-use-a-miyoogamelistxml-to-customise-game-names) for [Onion OS](https://github.com/OnionUI/Onion/) on Miyoo Mini devices.
+
+`miyoogamelist.xml` is similar to EmulationStation's `gamelist.xml` but only contains a `<path>`, `<name>` and `<image>` field for each `<game>`.
+
+Screenshots will always be placed in a sub-path of the input directory, under `./Imgs/`.
 
 #### Attract-Mode
 * Default game list location: `/home/pi/USER/.attract/romlists`

--- a/skyscraper.pro
+++ b/skyscraper.pro
@@ -45,6 +45,7 @@ HEADERS += src/skyscraper.h \
            src/abstractfrontend.h \
            src/emulationstation.h \
            src/retrobat.h \
+           src/miyoo.h \
            src/attractmode.h \
            src/pegasus.h \
            src/openretro.h \
@@ -95,6 +96,7 @@ SOURCES += src/main.cpp \
            src/abstractfrontend.cpp \
            src/emulationstation.cpp \
            src/retrobat.cpp \
+           src/miyoo.cpp \
            src/attractmode.cpp \
            src/pegasus.cpp \
            src/openretro.cpp \

--- a/src/compositor.cpp
+++ b/src/compositor.cpp
@@ -300,30 +300,45 @@ void Compositor::saveAll(GameEntry &game, QString completeBaseName)
     QString filename = "/" + completeBaseName + ".png";
     if(output.resType == "cover") {
       filename.prepend(config->coversFolder);
+      if(config->coversFolder == NULL) {
+        continue;
+      }
       if(config->skipExistingCovers && QFileInfo::exists(filename)) {
 	game.coverFile = filename;
 	continue;
       }
     } else if(output.resType == "screenshot") {
       filename.prepend(config->screenshotsFolder);
+      if(config->screenshotsFolder == NULL) {
+        continue;
+      }
       if(config->skipExistingScreenshots && QFileInfo::exists(filename)) {
 	game.screenshotFile = filename;
 	continue;
       }
     } else if(output.resType == "wheel") {
       filename.prepend(config->wheelsFolder);
+      if(config->wheelsFolder == NULL) {
+        continue;
+      }
       if(config->skipExistingWheels && QFileInfo::exists(filename)) {
 	game.wheelFile = filename;
 	continue;
       }
     } else if(output.resType == "marquee") {
       filename.prepend(config->marqueesFolder);
+      if(config->marqueesFolder == NULL) {
+        continue;
+      }
       if(config->skipExistingMarquees && QFileInfo::exists(filename)) {
-	game.marqueeFile = filename;
+ 	game.marqueeFile = filename;
 	continue;
       }
     } else if (output.resType == "texture") {
       filename.prepend(config->texturesFolder);
+      if(config->texturesFolder == NULL) {
+        continue;
+      }
       if (config->skipExistingTextures && QFileInfo::exists(filename)) {
         game.textureFile = filename;
         continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
   parser.addHelpOption();
   parser.addVersionOption();
   QCommandLineOption pOption("p", "The platform you wish to scrape.\n(Currently supports " + platforms + ".)", "PLATFORM", "");
-  QCommandLineOption fOption("f", "The frontend you wish to generate a gamelist for. Remember to leave out the '-s' option when using this in order to enable Skyscraper's gamelist generation mode.\n(Currently supports 'emulationstation', 'retrobat', 'attractmode' and 'pegasus'. Default is 'emulationstation')", "FRONTEND", "");
+  QCommandLineOption fOption("f", "The frontend you wish to generate a gamelist for. Remember to leave out the '-s' option when using this in order to enable Skyscraper's gamelist generation mode.\n(Currently supports 'emulationstation', 'retrobat', 'miyoo', 'attractmode' and 'pegasus'. Default is 'emulationstation')", "FRONTEND", "");
   QCommandLineOption eOption("e", "Set extra frontend option. This is required by the 'attractmode' frontend to set the emulator and optionally for the 'pegasus' frontend to set the launch command.\n(Default is none)", "STRING", "");
   QCommandLineOption iOption("i", "Folder which contains the game/rom files.\n(default is '/home/USER/RetroPie/roms/PLATFORM')", "PATH", "");
   QCommandLineOption gOption("g", "Game list export folder.\n(default depends on frontend)", "PATH", "");

--- a/src/miyoo.cpp
+++ b/src/miyoo.cpp
@@ -1,0 +1,207 @@
+/***************************************************************************
+ *            miyoo.cpp
+ *
+ *  Jan 18 2023
+ *  Copyright 2023 Nic Jansma
+ *  https://nicj.net
+ ****************************************************************************/
+/*
+ *  This file is part of skyscraper.
+ *
+ *  skyscraper is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  skyscraper is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with skyscraper; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ */
+
+#include "miyoo.h"
+#include "xmlreader.h"
+#include "strtools.h"
+#include "platform.h"
+
+#include <QDir>
+#include <QRegularExpression>
+
+Miyoo::Miyoo()
+{
+}
+
+bool Miyoo::loadOldGameList(const QString &gameListFileString)
+{
+  // Load old game list entries so we can preserve metadata later when assembling xml
+  XmlReader gameListReader;
+  if(gameListReader.setFile(gameListFileString)) {
+    oldEntries = gameListReader.getEntries(config->inputFolder);
+    return true;
+  }
+
+  return false;
+}
+
+bool Miyoo::skipExisting(QList<GameEntry> &gameEntries, QSharedPointer<Queue> queue) 
+{
+  gameEntries = oldEntries;
+
+  printf("Resolving missing entries...");
+  int dots = 0;
+  for(int a = 0; a < gameEntries.length(); ++a) {
+    dots++;
+    if(dots % 100 == 0) {
+      printf(".");
+      fflush(stdout);
+    }
+    QFileInfo current(gameEntries.at(a).path);
+    for(int b = 0; b < queue->length(); ++b) {
+      if(current.isFile()) {
+	if(current.fileName() == queue->at(b).fileName()) {
+	  queue->removeAt(b);
+	  // We assume filename is unique, so break after getting first hit
+	  break;
+	}
+      } else if(current.isDir()) {
+	// Use current.absoluteFilePath here since it is already a path. Otherwise it will use
+	// the parent folder
+	if(current.absoluteFilePath() == queue->at(b).absolutePath()) {
+	  queue->removeAt(b);
+	  // We assume filename is unique, so break after getting first hit
+	  break;
+	}
+      }
+    }
+  }
+  return true;
+}
+
+void Miyoo::preserveFromOld(GameEntry &entry)
+{
+  // NOP
+  if(entry.eSFavorite.isEmpty()) {
+    return;
+  }
+}
+
+void Miyoo::assembleList(QString &finalOutput, QList<GameEntry> &gameEntries)
+{
+  int dots = 0;
+  // Always make dotMod at least 1 or it will give "floating point exception" when modulo
+  int dotMod = gameEntries.length() * 0.1 + 1;
+  if(dotMod == 0)
+    dotMod = 1;
+  finalOutput.append("<?xml version=\"1.0\"?>\n<gameList>\n");
+  for(auto &entry: gameEntries) {
+    if(dots % dotMod == 0) {
+      printf(".");
+      fflush(stdout);
+    }
+    dots++;
+
+    QString entryType = "game";
+
+    QFileInfo entryInfo(entry.path);
+    if(entryInfo.isFile() && config->platform != "daphne") {
+      // Check if game is in subfolder. If so, change entry to <folder> type.
+      QString entryAbsolutePath = entryInfo.absolutePath();
+      // Check if path is exactly one subfolder beneath root platform folder (has one more '/')
+      if(entryAbsolutePath.count("/") == config->inputFolder.count("/") + 1) {
+	QString extensions = Platform::get().getFormats(config->platform,
+						  config->extensions,
+						  config->addExtensions);
+	// Check if the platform has both cue and bin extensions. Remove bin if it does to avoid count() below to be 2
+	// I thought about removing bin extensions entirely from platform.cpp, but I assume I've added them per user request at some point.
+	if(extensions.contains("*.cue") &&
+	   extensions.contains("*.bin")) {
+	  extensions.replace("*.bin", "");
+	  extensions = extensions.simplified();
+	}
+	// Check is subfolder has more roms than one, in which case we stick with <game>
+	if(QDir(entryAbsolutePath, extensions).count() == 1) {
+	  entryType = "folder";
+	  entry.path = entryAbsolutePath;
+	}
+      }
+    } else if(entryInfo.isDir()) {
+      entryType = "folder";
+    }
+
+    // Preserve certain data from old game list entry, but only for empty data
+    preserveFromOld(entry);
+
+    if(config->platform == "daphne") {
+      entry.path.replace("daphne/roms/", "daphne/").replace(".zip", ".daphne");
+      entryType = "game";
+    }
+
+    if(config->relativePaths) {
+      entry.path.replace(config->inputFolder, ".");
+    }
+
+    finalOutput.append("  <" + entryType + ">\n");
+    finalOutput.append("    <path>" + StrTools::xmlEscape(entry.path) + "</path>\n");
+    finalOutput.append("    <name>" + StrTools::xmlEscape(entry.title) + "</name>\n");
+    if(entry.screenshotFile.isEmpty()) {
+      finalOutput.append("    <image />\n");
+    } else {
+      finalOutput.append("    <image>" + (config->relativePaths?StrTools::xmlEscape(entry.screenshotFile).replace(config->inputFolder, "."):StrTools::xmlEscape(entry.screenshotFile)) + "</image>\n");
+    }
+    finalOutput.append("  </" + entryType + ">\n");
+  }
+  finalOutput.append("</gameList>");
+}
+
+bool Miyoo::canSkip()
+{
+  return true;
+}
+
+QString Miyoo::getGameListFileName()
+{
+  return QString("miyoogamelist.xml");
+}
+
+QString Miyoo::getInputFolder()
+{
+  return QString(QDir::homePath() + "/RetroPie/roms/" + config->platform);
+}
+
+QString Miyoo::getGameListFolder()
+{
+  return config->inputFolder;
+}
+
+QString Miyoo::getCoversFolder()
+{
+  return NULL;
+}
+
+QString Miyoo::getScreenshotsFolder()
+{
+  return this->getGameListFolder() + "/Imgs";
+}
+
+QString Miyoo::getWheelsFolder()
+{
+  return NULL;
+}
+
+QString Miyoo::getMarqueesFolder()
+{
+  return NULL;
+}
+
+QString Miyoo::getTexturesFolder() {
+  return NULL;
+}
+
+QString Miyoo::getVideosFolder()
+{
+  return NULL;
+}

--- a/src/miyoo.h
+++ b/src/miyoo.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *            miyoo.h
+ *
+ *  Jan 18 2023
+ *  Copyright 2023 Nic Jansma
+ *  https://nicj.net
+ ****************************************************************************/
+/*
+ *  This file is part of skyscraper.
+ *
+ *  skyscraper is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  skyscraper is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with skyscraper; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ */
+
+#ifndef MIYOO_H
+#define MIYOO_H
+
+#include "abstractfrontend.h"
+
+class Miyoo : public AbstractFrontend
+{
+  Q_OBJECT
+
+public:
+  Miyoo();
+  void assembleList(QString &finalOutput, QList<GameEntry> &gameEntries) override;
+  bool skipExisting(QList<GameEntry> &gameEntries, QSharedPointer<Queue> queue) override;
+  bool canSkip() override;
+  bool loadOldGameList(const QString &gameListFileString) override;
+  void preserveFromOld(GameEntry &entry) override;
+  QString getGameListFileName() override;
+  QString getInputFolder() override;
+  QString getGameListFolder() override;
+  QString getCoversFolder() override;
+  QString getScreenshotsFolder() override;
+  QString getWheelsFolder() override;
+  QString getMarqueesFolder() override;
+  QString getTexturesFolder() override;
+  QString getVideosFolder() override;
+
+};
+
+#endif // MIYOO_H

--- a/src/scripter.cpp
+++ b/src/scripter.cpp
@@ -56,10 +56,12 @@ Scripter::Scripter()
   printf("Available frontends:\n");
   printf("* \033[1;33memulationstation\033[0m\n");
   printf("* \033[1;33mretrobat\033[0m\n");
+  printf("* \033[1;33mmiyoo\033[0m\n");
   printf("* \033[1;33mattractmode\033[0m\n");
   printf("* \033[1;33mpegasus\033[0m\n");
   while(frontendStr != "emulationstation" &&
 	frontendStr != "retrobat" &&
+	frontendStr != "miyoo" &&
 	frontendStr != "attractmode" &&
 	frontendStr != "pegasus" &&
 	frontendStr != "") {
@@ -128,7 +130,7 @@ Scripter::Scripter()
   getline(std::cin, bracketsStr);
 
   std::string relativeStr = "";
-  if(frontendStr == "emulationstation" || frontendStr == "retrobat") {
+  if(frontendStr == "emulationstation" || frontendStr == "retrobat" || frontendStr == "miyoo") {
     printf("\033[1;34mDo you wish to force rom relative paths in the exported gamelist.xml file?\033[0m (y/N)? ");
     getline(std::cin, relativeStr);
   }

--- a/src/skyscraper.cpp
+++ b/src/skyscraper.cpp
@@ -49,6 +49,7 @@
 
 #include "emulationstation.h"
 #include "retrobat.h"
+#include "miyoo.h"
 #include "attractmode.h"
 #include "pegasus.h"
 
@@ -86,12 +87,22 @@ void Skyscraper::run()
   }
   printf("Input folder:       '\033[1;32m%s\033[0m'\n", config.inputFolder.toStdString().c_str());
   printf("Game list folder:   '\033[1;32m%s\033[0m'\n", config.gameListFolder.toStdString().c_str());
-  printf("Covers folder:      '\033[1;32m%s\033[0m'\n", config.coversFolder.toStdString().c_str());
-  printf("Screenshots folder: '\033[1;32m%s\033[0m'\n", config.screenshotsFolder.toStdString().c_str());
-  printf("Wheels folder:      '\033[1;32m%s\033[0m'\n", config.wheelsFolder.toStdString().c_str());
-  printf("Marquees folder:    '\033[1;32m%s\033[0m'\n", config.marqueesFolder.toStdString().c_str());
-  printf("Textures folder:    '\033[1;32m%s\033[0m'\n", config.texturesFolder.toStdString().c_str());
-  if(config.videos) {
+  if(config.coversFolder != NULL) {
+    printf("Covers folder:      '\033[1;32m%s\033[0m'\n", config.coversFolder.toStdString().c_str());
+  }
+  if(config.screenshotsFolder != NULL) {
+    printf("Screenshots folder: '\033[1;32m%s\033[0m'\n", config.screenshotsFolder.toStdString().c_str());
+  }
+  if(config.wheelsFolder != NULL) {
+    printf("Wheels folder:      '\033[1;32m%s\033[0m'\n", config.wheelsFolder.toStdString().c_str());
+  }
+  if(config.marqueesFolder != NULL) {
+    printf("Marquees folder:    '\033[1;32m%s\033[0m'\n", config.marqueesFolder.toStdString().c_str());
+  }
+  if(config.texturesFolder != NULL) {
+    printf("Textures folder:    '\033[1;32m%s\033[0m'\n", config.texturesFolder.toStdString().c_str());
+  }
+  if(config.videos && config.videosFolder != NULL) {
     printf("Videos folder:      '\033[1;32m%s\033[0m'\n", config.videosFolder.toStdString().c_str());
   }
   printf("Cache folder:       '\033[1;32m%s\033[0m'\n", config.cacheFolder.toStdString().c_str());
@@ -202,32 +213,42 @@ void Skyscraper::run()
     checkForFolder(gameListDir);
   config.gameListFolder = gameListDir.absolutePath();
 
-  QDir coversDir(config.coversFolder);
-  if(config.scraper == "cache" && !config.pretend)
-    checkForFolder(coversDir);
-  config.coversFolder = coversDir.absolutePath();
+  if(config.coversFolder != NULL) {
+    QDir coversDir(config.coversFolder);
+    if(config.scraper == "cache" && !config.pretend)
+      checkForFolder(coversDir);
+    config.coversFolder = coversDir.absolutePath();
+  }
 
-  QDir screenshotsDir(config.screenshotsFolder);
-  if(config.scraper == "cache" && !config.pretend)
-    checkForFolder(screenshotsDir);
-  config.screenshotsFolder = screenshotsDir.absolutePath();
+  if(config.screenshotsFolder != NULL) {
+    QDir screenshotsDir(config.screenshotsFolder);
+    if(config.scraper == "cache" && !config.pretend)
+      checkForFolder(screenshotsDir);
+    config.screenshotsFolder = screenshotsDir.absolutePath();
+  }
 
-  QDir wheelsDir(config.wheelsFolder);
-  if(config.scraper == "cache" && !config.pretend)
-    checkForFolder(wheelsDir);
-  config.wheelsFolder = wheelsDir.absolutePath();
+  if(config.wheelsFolder != NULL) {
+    QDir wheelsDir(config.wheelsFolder);
+    if(config.scraper == "cache" && !config.pretend)
+      checkForFolder(wheelsDir);
+    config.wheelsFolder = wheelsDir.absolutePath();
+  }
 
-  QDir marqueesDir(config.marqueesFolder);
-  if(config.scraper == "cache" && !config.pretend)
-    checkForFolder(marqueesDir);
-  config.marqueesFolder = marqueesDir.absolutePath();
+  if(config.marqueesFolder != NULL) {
+    QDir marqueesDir(config.marqueesFolder);
+    if(config.scraper == "cache" && !config.pretend)
+      checkForFolder(marqueesDir);
+    config.marqueesFolder = marqueesDir.absolutePath();
+  }
 
-  QDir texturesDir(config.texturesFolder);
-  if (config.scraper == "cache" && !config.pretend)
-    checkForFolder(texturesDir);
-  config.texturesFolder = texturesDir.absolutePath();
+  if(config.texturesFolder != NULL) {
+    QDir texturesDir(config.texturesFolder);
+    if (config.scraper == "cache" && !config.pretend)
+      checkForFolder(texturesDir);
+    config.texturesFolder = texturesDir.absolutePath();
+  }
 
-  if(config.videos) {
+  if(config.videos && config.videosFolder != NULL) {
     QDir videosDir(config.videosFolder);
     if(config.scraper == "cache" && !config.pretend)
       checkForFolder(videosDir);
@@ -679,6 +700,7 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
   settings.endGroup();
   if(parser.isSet("f") && (parser.value("f") == "emulationstation" ||
 			   parser.value("f") == "retrobat" ||
+			   parser.value("f") == "miyoo" ||
 			   parser.value("f") == "attractmode" ||
 			   parser.value("f") == "pegasus")) {
     config.frontend = parser.value("f");
@@ -687,6 +709,8 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
     frontend = new EmulationStation;
   } else if(config.frontend == "retrobat") {
     frontend = new RetroBat;
+  } else if(config.frontend == "miyoo") {
+    frontend = new Miyoo;
   } else if(config.frontend == "attractmode") {
     frontend = new AttractMode;
   } else if(config.frontend == "pegasus") {
@@ -1110,7 +1134,7 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
     config.mediaFolder = settings.value("mediaFolder").toString();
     mediaFolderSet = true;
   }
-  if(settings.contains("mediaFolderHidden") && (config.frontend == "emulationstation" || config.frontend == "retrobat")) {
+  if(settings.contains("mediaFolderHidden") && (config.frontend == "emulationstation" || config.frontend == "retrobat" || config.frontend == "miyoo")) {
     config.mediaFolderHidden = settings.value("mediaFolderHidden").toBool();
   }
   if(settings.contains("skipped")) {
@@ -1517,7 +1541,7 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
   config.marqueesFolder = frontend->getMarqueesFolder();
   config.texturesFolder = frontend->getTexturesFolder();
   config.videosFolder = frontend->getVideosFolder();
-
+  
   // Choose default scraper for chosen platform if none has been set yet
   if(config.scraper.isEmpty()) {
     config.scraper = Platform::get().getDefaultScraper();


### PR DESCRIPTION
Adds `miyoogamelist.xml` frontend support (for [Onion OS](https://github.com/OnionUI/Onion/) on Miyoo Mini devices).

`miyoogamelist.xml` is like `gamelist.xml` for EmulationStation, but only supports `<path>`, `<name>` and `<image>` for each `<game>`.

e.g.

```
<?xml version="1.0"?>
<gameList>
  <game>
    <path>./3-D Tetris (USA).7z</path>
    <name>3-D Tetris (USA)</name>
    <image>./Imgs/3-D Tetris (USA).png</image>
  </game>
...
```

OnionOS also assumes media (screenshots) will be in an `Imgs/` subfolder.  No other media is supported, and this change allows a frontend to specify `NULL` for paths (such as marquees or covers) so they won't get created/written.