### PR TITLE
cacheIdFromData exceptions - add po/dsk/nib suffixes for apple2 platform

### DIFF
--- a/src/nametools.cpp
+++ b/src/nametools.cpp
@@ -502,7 +502,9 @@ QString NameTools::getCacheId(const QFileInfo &info)
      info.suffix() == "scummvm" || info.suffix() == "mds" ||
      info.suffix() == "zip" || info.suffix() == "7z" ||
      info.suffix() == "gdi" || info.suffix() == "ml" ||
-     info.suffix() == "bat" || info.suffix() == "au3") {
+     info.suffix() == "bat" || info.suffix() == "au3" ||
+     info.suffix() == "po" || info.suffix() == "dsk" ||
+     info.suffix() == "nib") {
     cacheIdFromData = false;
   }
   // If file is larger than 50 MBs, use filename checksum for cache id for optimization reasons


### PR DESCRIPTION
Apple2 disk images are volatile and may change content. This adds their extensions to list of exceptions to be cached by filename instead of content.