### PR TITLE
add tg16 platform

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -84,6 +84,7 @@
 		{"name":"snes","scrapers":["openretro", "screenscraper"],"formats":["*.smc", "*.sfc", "*.fig", "*.swc", "*.mgd", "*.bin"],"aliases":["super nintendo (snes)", "super nintendo entertainment system (snes)", "super nintendo", "super famicom", "nintendo power", "satellaview", "sufami turbo", "snes - super mario world hacks", "super nintendo msu-1"]},
 		{"name":"steam","scrapers":["screenscraper"],"formats":[],"aliases":["pc dos", "pc win3.xx", "dos", "windows", "windows apps", "pc (microsoft windows)", "steamos", "microsoft xbox one", "sony playstation 4"]},
 		{"name":"switch","scrapers":["screenscraper"],"formats":["*.xci", "*.nsp", "*.nca"],"aliases":["nintendo switch"]},
+		{"name":"tg16","scrapers":["openretro","screenscraper"],"formats":["*.pce", "*.chd", "*.cue"],"aliases":["turbografx 16", "turbografx cd", "turbografx-16", "turbografx-16/pc engine", "turbografx-16/pc engine cd", "pc engine", "pc engine cd-rom", "pc engine supergrafx"]},
 		{"name":"ti99","scrapers":["screenscraper"],"formats":["*.ctg"],"aliases":["ti-99/4a", "texas instruments ti-99", "texas instruments ti-99/4a"]},
 		{"name":"trs-80","scrapers":["screenscraper"],"formats":["*.dsk"],"aliases":["trs-80 color computer"]},
 		{"name":"vectrex","scrapers":["screenscraper"],"formats":["*.bin", "*.gam", "*.vec"],"aliases":[]},

--- a/screenscraper.json
+++ b/screenscraper.json
@@ -83,6 +83,7 @@
 		{"name":"snes","id":4},
 		{"name":"steam","id":138},
 		{"name":"switch","id":225},
+		{"name":"tg16","id":31},
 		{"name":"ti99","id":205},
 		{"name":"trs-80","id":144},
 		{"name":"vectrex","id":102},


### PR DESCRIPTION
Many themes support an independent 'tg16' folder. This adds a 'tg16' system/alias for pc engine titles.