### PR TITLE
sorts the platforms in `--help` output ascending 

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -76,6 +76,7 @@ void Platform::loadConfig(const QString& configPath)
             platformToAliases[platformName].push_back(aliasName);
         }
     }
+    platforms.sort();
 }
 
 void Platform::clearConfigData()


### PR DESCRIPTION
Esp. when the user provides an unsorted (by key "name") `platforms.json`